### PR TITLE
Add jacoco for some coverage reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,7 @@ jobs:
           java-version: "11"
 
       - name: Run Tests
-        run: ./gradlew test -i
+        run: ./gradlew jacocoTestReportDebug
+
+      - name: Generate Report
+        run: ./gradlew jacocoTestReportMerged

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,8 +70,23 @@ dependencies {
     coreLibraryDesugaring deps.desugar
 
     testImplementation testDeps.junit
+    testImplementation testDeps.mockk.core
+    testImplementation testDeps.androidX.lifecycle
+    testImplementation testDeps.kotlinCoroutines
 }
 
 kapt {
     correctErrorTypes true
 }
+
+junitJacoco {
+    excludes = [
+        '**/hilt_aggregated_deps/**',
+        '**/HiltComponent**/**',
+        '**/**codegen**/',
+        '**/BuildConfig**',
+
+        '**/**MainActivity**',
+    ]
+}
+

--- a/app/src/main/java/com/fueledbycaffeine/mivote/ui/voter/VoterRegistrationViewModel.kt
+++ b/app/src/main/java/com/fueledbycaffeine/mivote/ui/voter/VoterRegistrationViewModel.kt
@@ -7,7 +7,6 @@ import com.fueledbycaffeine.mivote.data.VoterInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.michiganelections.api.model.VoterRegistration
 import io.michiganelections.api.service.ApiService
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -18,11 +17,7 @@ class VoterRegistrationViewModel @Inject constructor(
   private val registration = MutableLiveData<VoterRegistration>()
   val registrationLiveData: LiveData<VoterRegistration> = registration
 
-  init {
-    Timber.e("Initialized the thing at least")
-  }
-
-  suspend fun checkRegistration(voterInfo: VoterInfo) {
+  suspend fun checkRegistration(voterInfo: VoterInfo): VoterRegistration {
     val registrationResult = api.getVoter(
       firstName = voterInfo.firstName,
       lastName = voterInfo.lastName,
@@ -30,5 +25,6 @@ class VoterRegistrationViewModel @Inject constructor(
       zipcode = voterInfo.zipcode
     )
     registration.value = registrationResult
+    return registrationResult
   }
 }

--- a/app/src/test/java/com/fueledbycaffeine/mivote/ui/voter/VoterRegistrationViewModelTest.kt
+++ b/app/src/test/java/com/fueledbycaffeine/mivote/ui/voter/VoterRegistrationViewModelTest.kt
@@ -1,0 +1,63 @@
+package com.fueledbycaffeine.mivote.ui.voter
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.fueledbycaffeine.mivote.data.VoterInfo
+import com.fueledbycaffeine.mivote.util.evaluateLiveDataSequence
+import io.michiganelections.api.model.VoterRegistration
+import io.michiganelections.api.service.ApiService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.time.LocalDate
+
+@ExperimentalCoroutinesApi
+class VoterRegistrationViewModelTest {
+
+  @Rule @JvmField val testRule = InstantTaskExecutorRule()
+
+  private lateinit var mockApiService: ApiService
+  private lateinit var viewModel: VoterRegistrationViewModel
+
+  @Before
+  fun setup() {
+    mockApiService = mockk()
+    viewModel = VoterRegistrationViewModel(
+      api = mockApiService
+    )
+  }
+
+  @Test
+  fun testCheckRegistration() = runBlockingTest {
+    val firstName = "John"
+    val lastName = "Doe"
+    val birthdate = LocalDate.now()
+    val zipcode = "12345"
+    val expectedResult = mockk<VoterRegistration>()
+
+    coEvery { mockApiService.getVoter(firstName, lastName, birthdate, zipcode) } returns expectedResult
+
+    evaluateLiveDataSequence(
+      liveData = viewModel.registrationLiveData,
+      evaluators = listOf { registration ->
+        Assert.assertEquals(expectedResult, registration)
+      },
+      block = {
+        val voterInfo = VoterInfo(
+          firstName = firstName,
+          lastName = lastName,
+          birthdate = birthdate,
+          zipcode = zipcode
+        )
+        Assert.assertEquals(expectedResult, viewModel.checkRegistration(voterInfo))
+      }
+    )
+
+    coVerify { mockApiService.getVoter(firstName, lastName, birthdate, zipcode) }
+  }
+}

--- a/app/src/test/java/com/fueledbycaffeine/mivote/util/evaluateLiveDataSequence.kt
+++ b/app/src/test/java/com/fueledbycaffeine/mivote/util/evaluateLiveDataSequence.kt
@@ -1,0 +1,25 @@
+package com.fueledbycaffeine.mivote.util
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.Assert
+
+inline fun<reified T : Any> evaluateLiveDataSequence(liveData: LiveData<T>, evaluators: List<(T) -> Unit>, block: () -> Unit) {
+  val observer = mockk<Observer<T>>()
+  val slot = slot<T>()
+  val list = arrayListOf<T>()
+
+  every { observer.onChanged(capture(slot)) } answers { list.add(slot.captured) }
+  liveData.observeForever(observer)
+
+  block()
+
+  Assert.assertEquals("LiveData did not emit expected number of times.", evaluators.size, list.size)
+
+  list.forEachIndexed { index, value ->
+    evaluators[index](value)
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,15 @@ buildscript {
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.36'
 
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detekt_version"
+
+        classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.16.0"
     }
+}
+
+apply plugin: "com.vanniktech.android.junit.jacoco"
+
+junitJacoco {
+    jacocoVersion = '0.8.7'
 }
 
 subprojects {

--- a/michiganelections_api/build.gradle
+++ b/michiganelections_api/build.gradle
@@ -54,3 +54,15 @@ dependencies {
     testImplementation testDeps.androidX.lifecycle
     testImplementation testDeps.kotlinCoroutines
 }
+
+junitJacoco {
+    excludes = [
+        '**/hilt_aggregated_deps/**',
+        '**/HiltComponent**/**',
+        '**/**codegen**/',
+        '**/BuildConfig**',
+
+        '**/**model/**',
+    ]
+}
+

--- a/michiganelections_api/src/main/java/io/michiganelections/api/injection/ApiModule.kt
+++ b/michiganelections_api/src/main/java/io/michiganelections/api/injection/ApiModule.kt
@@ -17,6 +17,14 @@ import timber.log.Timber
 @InstallIn(SingletonComponent::class)
 class ApiModule {
 
+  private val httpLoggingInterceptor = HttpLoggingInterceptor { message ->
+    Timber.tag("HTTP").d(message)
+  }
+    .apply {
+      level = HttpLoggingInterceptor.Level.BASIC
+    }
+
+
   @Provides
   fun provideMoshi(): Moshi {
     return Moshi.Builder()
@@ -24,14 +32,7 @@ class ApiModule {
   }
 
   @Provides
-  fun provideHttpLoggingInterceptor(): HttpLoggingInterceptor {
-    val loggingInterceptor = HttpLoggingInterceptor { message -> Timber.tag("HTTP").d(message) }
-    loggingInterceptor.level = HttpLoggingInterceptor.Level.BASIC
-    return loggingInterceptor
-  }
-
-  @Provides
-  fun provideOkHttpClient(httpLoggingInterceptor: HttpLoggingInterceptor): OkHttpClient {
+  fun provideOkHttpClient(): OkHttpClient {
     return OkHttpClient.Builder()
       .addInterceptor(httpLoggingInterceptor)
       .build()

--- a/michiganelections_api/src/test/java/io/michiganelections/api/injection/ApiModuleTest.kt
+++ b/michiganelections_api/src/test/java/io/michiganelections/api/injection/ApiModuleTest.kt
@@ -1,0 +1,44 @@
+package io.michiganelections.api.injection
+
+import com.squareup.moshi.Moshi
+import io.michiganelections.api.service.ApiServiceImpl
+import io.mockk.mockk
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class ApiModuleTest {
+
+  private lateinit var apiModule: ApiModule
+
+  @Before
+  fun setup() {
+    apiModule = ApiModule()
+  }
+
+  @Test
+  fun testProvideMoshi() {
+    Assert.assertNotNull(apiModule.provideMoshi())
+  }
+
+  @Test
+  fun testProvideHttpClient() {
+    Assert.assertNotNull(apiModule.provideOkHttpClient())
+  }
+
+  @Test
+  fun testProvideRetrofit() {
+    val mockClient = mockk<OkHttpClient>()
+    val mockMoshi = Moshi.Builder().build()
+
+    Assert.assertNotNull(apiModule.provideRetrofit(mockClient, mockMoshi))
+  }
+
+  @Test
+  fun testProvideApiService() {
+    val impl = mockk<ApiServiceImpl>()
+    Assert.assertEquals(impl, apiModule.provideApiService(impl))
+  }
+}

--- a/michiganelections_api/src/test/java/io/michiganelections/api/service/ApiTest.kt
+++ b/michiganelections_api/src/test/java/io/michiganelections/api/service/ApiTest.kt
@@ -1,11 +1,8 @@
-package io.michiganelections.api
+package io.michiganelections.api.service
 
 import io.michiganelections.api.model.Election
 import io.michiganelections.api.model.ResultPage
 import io.michiganelections.api.model.VoterRegistration
-import io.michiganelections.api.service.ApiService
-import io.michiganelections.api.service.ApiServiceImpl
-import io.michiganelections.api.service.Endpoints
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every


### PR DESCRIPTION
Started down this path... Now I'm not sure if it's ultimately useful. Theoretically we could make sure that coverage doesn't dip, but I'm not 100% sure yet how to write composable tests (although everything I've heard about it has been positive)... Anyway, this will create a coverage report:

```
./gradlew jacocoTestReportDebug
./gradlew jacocoTestReportMerged
```

You can then view the report here (replace `PATH_TO_YOUR_REPO`):
`file:///PATH_TO_YOUR_REPO//build/reports/jacoco/index.html`